### PR TITLE
Add Leonardo API support

### DIFF
--- a/flux_dev_checkpoint_example.json
+++ b/flux_dev_checkpoint_example.json
@@ -1,0 +1,17 @@
+{
+  "nodes": {
+    "1": {
+      "class_type": "KSampler",
+      "inputs": {"prompt": "__PROMPT__"}
+    },
+    "2": {
+      "class_type": "SaveImage",
+      "inputs": {
+        "filename_prefix": "flux_dev",
+        "prompt": "@node:1",
+        "output_path": "output"
+      }
+    }
+  },
+  "connections": [[1, 2]]
+}

--- a/flux_dev_checkpoint_example.json
+++ b/flux_dev_checkpoint_example.json
@@ -1,5 +1,5 @@
 {
-  "nodes": {
+  "prompt": {
     "1": {
       "class_type": "KSampler",
       "inputs": {"prompt": "__PROMPT__"}
@@ -8,10 +8,9 @@
       "class_type": "SaveImage",
       "inputs": {
         "filename_prefix": "flux_dev",
-        "prompt": "@node:1",
+        "images": "@node:1",
         "output_path": "output"
       }
     }
-  },
-  "connections": [[1, 2]]
+  }
 }

--- a/main.py
+++ b/main.py
@@ -129,7 +129,9 @@ COMFYUI_URL = "http://127.0.0.1:8188"
 COMFYUI_WORKFLOW_FILE = os.path.join(application_path, "flux_dev_checkpoint_example.json")
 COMFYUI_MAX_RETRIES = 3
 COMFYUI_POLL_INTERVAL = 2
-COMFYUI_POLL_ATTEMPTS = 30
+# Увеличено время ожидания результата до ~10 минут на картинку
+# (300 попыток по 2 секунды каждая)
+COMFYUI_POLL_ATTEMPTS = 300
 
 script_dir = application_path
 images_dir = os.path.join(script_dir, "Images")

--- a/main.py
+++ b/main.py
@@ -133,7 +133,8 @@ COMFYUI_POLL_INTERVAL = 2
 # (300 попыток по 2 секунды каждая)
 COMFYUI_POLL_ATTEMPTS = 300
 # Таймаут в секундах для HTTP-запросов к локальному ComfyUI
-COMFYUI_REQUEST_TIMEOUT = 180
+# Увеличено до 600 (10 минут), чтобы дождаться завершения долгих задач
+COMFYUI_REQUEST_TIMEOUT = 600
 
 script_dir = application_path
 images_dir = os.path.join(script_dir, "Images")

--- a/main.py
+++ b/main.py
@@ -79,6 +79,11 @@ DEFAULT_PREFIXES = [
 ]
 DEFAULT_PREFIXES_LEN = len(DEFAULT_PREFIXES)
 
+# Суффикс для дополнительной четкости изображения
+SHARP_PROMPT_SUFFIX = (
+    " Ensure the final image is perfectly sharp, high definition, and crisp, with no blurriness."
+)
+
 # --- НОВЫЕ КОНСТАНТЫ для FLUX моделей ---
 FLUX_SCHNELL_MODEL_NAME = "black-forest-labs/FLUX.1-schnell"
 FLUX_DEV_MODEL_NAME = "black-forest-labs/FLUX.1-dev"
@@ -620,7 +625,9 @@ def worker(task_id, task_data):
 
             # Шаг 4: Формирование финального промпта
             selected_prefix = random.choice(DEFAULT_PREFIXES)
-            final_prompt_for_image = selected_prefix + together_prompt_content
+            final_prompt_for_image = (
+                selected_prefix + together_prompt_content + SHARP_PROMPT_SUFFIX
+            )
             log_message(
                 f"{log_prefix} Финальный промпт (длина {len(final_prompt_for_image)}): {final_prompt_for_image[:200]}...",
                 level=logging.DEBUG)
@@ -1601,9 +1608,9 @@ def _on_flux_toggle(model):
         flux_schnell_var.set(0)
 
 checkbox_flux_schnell = ctk.CTkCheckBox(together_image_frame, text="FLUX.1 Schnell ($0.003)", variable=flux_schnell_var, command=lambda: _on_flux_toggle('schnell'))
-checkbox_flux_schnell.grid(row=1, column=0, sticky="w")
+checkbox_flux_schnell.grid(row=1, column=0, sticky="w", padx=(5, 2))
 checkbox_flux_dev = ctk.CTkCheckBox(together_image_frame, text="FLUX.1 [dev] ($0.025)", variable=flux_dev_var, command=lambda: _on_flux_toggle('dev'))
-checkbox_flux_dev.grid(row=1, column=1, sticky="w")
+checkbox_flux_dev.grid(row=1, column=1, sticky="w", padx=(5, 0))
 
 leonardo_frame = ctk.CTkFrame(common_settings_frame, fg_color="transparent")
 leonardo_frame.grid(row=2, column=0, columnspan=2, padx=10, pady=5, sticky="ew")

--- a/main.py
+++ b/main.py
@@ -586,9 +586,21 @@ def call_comfyui_flux_dev_with_retry(prompt: str):
 
     try:
         with open(COMFYUI_WORKFLOW_FILE, "r", encoding="utf-8") as wf:
-            workflow = json.load(wf)
+            workflow_raw = json.load(wf)
     except Exception as e:
         raise RuntimeError(f"Не удалось загрузить workflow ComfyUI: {e}") from e
+
+    # В сохраненных файлах могут использоваться разные ключи
+    # ("prompt", "nodes", или сам словарь). Выбираем корректный.
+    if isinstance(workflow_raw, dict):
+        if "prompt" in workflow_raw:
+            workflow = workflow_raw["prompt"]
+        elif "nodes" in workflow_raw:
+            workflow = workflow_raw["nodes"]
+        else:
+            workflow = workflow_raw
+    else:
+        raise RuntimeError("Некорректный формат workflow ComfyUI")
 
     def _replace_prompt(obj):
         if isinstance(obj, dict):


### PR DESCRIPTION
## Summary
- connect to both Together FLUX and Leonardo AI image generation APIs
- add Leonardo API key field in the GUI and settings
- ensure only one provider key is supplied
- choose provider when running generation

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_688a2ef654cc832b996e66685c37b50a